### PR TITLE
Remove unused ubiquity listeners

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,6 @@
 {
   "name": "Wallet",
   "description": "Allows users to register their wallets to collect rewards.",
-  "ubiquity:listeners": [
-    "issue_comment.created"
-  ],
   "skipBotEvents": false,
   "commands": {
     "wallet": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,6 +18,9 @@ export async function plugin(context: Context) {
   }
 
   if (context.eventName === "issue_comment.created") {
+    if (!context.payload.comment.body.trim().startsWith("/")) {
+      return context.logger.info("Skipping because comment is not a command", { body: context.payload.comment.body });
+    }
     const commandParser = new CommandParser(context);
     try {
       const args = context.payload.comment.body.trim().split(/\s+/);


### PR DESCRIPTION
Resolves #61

QA: https://github.com/Meniole/command-wallet/issues/10

Basically the problem was that this plugin still had the comment listener which was triggered for any comment and had no safeguard. So I added one and removed the listener so the kernel calls it only for commands.
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
